### PR TITLE
Make handling of empty input robust

### DIFF
--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -458,6 +458,112 @@ end
         end
     end
 end
+@testset "Multiple lines leading and a lot of surrounding whitespace" begin
+    for alg in [:serial, :singlebuffer, :doublebuffer]
+        @testset "Int $alg" begin
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("   1   \n   1   "), ctx, _force=alg)
+
+            @test ctx.elements == [1,1]
+        end
+        @testset "Float64 $alg" begin
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     1.0      \n      1.0      "), ctx, _force=alg)
+
+            @test ctx.elements == [1.0, 1.0]
+        end
+        @testset "String $alg" begin
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("    \"1.0\"     \n      \"1.0\"      "), ctx, _force=alg)
+
+            @test ctx.elements == ["1.0","1.0"]
+        end
+        @testset "Bool $alg" begin
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("       false        \n       true      "), ctx, _force=alg)
+
+            @test ctx.elements == [false, true]
+        end
+        @testset "Null $alg" begin
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("      null       \n null      "), ctx, _force=alg)
+
+            @test ctx.elements == [nothing,nothing]
+        end
+        @testset "Array $alg" begin
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer(" [] \n [] "), ctx, _force=alg)
+
+            @test ctx.elements == [[],[]]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("       [1, 2]      \n       [1, 2]      "), ctx, _force=alg)
+
+            @test ctx.elements == [[1, 2],[1, 2]]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("    [1.0, 2.0]     \n      [1.0, 2.0]      "), ctx, _force=alg)
+
+            @test ctx.elements == [[1.0, 2.0],[1.0, 2.0]]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     [\"1\", \"2\"]     \n   [\"1\", \"2\"]     "), ctx, _force=alg)
+
+            @test ctx.elements == [["1", "2"],["1", "2"]]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("      [true, false]     \n      [true, false]    "), ctx, _force=alg)
+
+            @test ctx.elements == [[true, false],[true, false]]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     [null, null]      \n      [null, null]     "), ctx, _force=alg)
+
+            @test ctx.elements == [[nothing, nothing],[nothing, nothing]]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     [{}]     \n     [{}]     "), ctx, _force=alg)
+
+            @test ctx.elements == [[Dict{Symbol,Any}()],[Dict{Symbol,Any}()]]
+        end
+        @testset "Object $alg" begin
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     {}     \n     {}     "), ctx, _force=alg)
+
+            @test ctx.elements == [Dict{Symbol,Any}(),Dict{Symbol,Any}()]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     {\"a\": 1}     \n     {\"a\": 1}     "), ctx, _force=alg)
+
+            @test ctx.elements == [Dict{Symbol,Any}(:a => 1),Dict{Symbol,Any}(:a => 1)]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     {\"a\": 1.0}     \n     {\"a\": 1.0}     "), ctx, _force=alg)
+
+            @test ctx.elements == [Dict{Symbol,Any}(:a => 1.0),Dict{Symbol,Any}(:a => 1.0)]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     {\"a\": \"1\"}     \n     {\"a\": \"1\"}     "), ctx, _force=alg)
+
+            @test ctx.elements == [Dict{Symbol,Any}(:a => "1"),Dict{Symbol,Any}(:a => "1")]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     {\"a\": true}     \n     {\"a\": true}     "), ctx, _force=alg)
+
+            @test ctx.elements == [Dict{Symbol,Any}(:a => true),Dict{Symbol,Any}(:a => true)]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     {\"a\": null}     \n     {\"a\": null}     "), ctx, _force=alg)
+
+            @test ctx.elements == [Dict{Symbol,Any}(:a => nothing),Dict{Symbol,Any}(:a => nothing)]
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("     {\"a\": []}     \n     {\"a\": []}     "), ctx, _force=alg)
+
+            @test ctx.elements == [Dict{Symbol,Any}(:a => []),Dict{Symbol,Any}(:a => [])]
+        end
+    end
+end
 
 
 @testset "Multiple lines leading and trailing whitespace with BOM" begin
@@ -690,6 +796,39 @@ end
             ChunkedJSONL.parse_file(IOBuffer("\xef\xbb\xbf {\"a\": []} \n {\"a\": []} "), ctx, _force=alg, buffersize=11)
 
             @test ctx.elements == [Dict{Symbol,Any}(:a => []),Dict{Symbol,Any}(:a => [])]
+        end
+        @testset "Empty input $alg" begin
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer(""), ctx, _force=alg, buffersize=1)
+            @test isempty(ctx.elements)
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer(" "), ctx, _force=alg, buffersize=1)
+            @test isempty(ctx.elements)
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer(" "), ctx, _force=alg, buffersize=2)
+            @test isempty(ctx.elements)
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("  "), ctx, _force=alg, buffersize=1)
+            @test isempty(ctx.elements)
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("\xef\xbb\xbf"), ctx, _force=alg, buffersize=3)
+            @test isempty(ctx.elements)
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("\xef\xbb\xbf "), ctx, _force=alg, buffersize=3)
+            @test isempty(ctx.elements)
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("\xef\xbb\xbf "), ctx, _force=alg, buffersize=4)
+            @test isempty(ctx.elements)
+
+            ctx = ValueExtractionContext()
+            ChunkedJSONL.parse_file(IOBuffer("\xef\xbb\xbf  "), ctx, _force=alg, buffersize=3)
+            @test isempty(ctx.elements)
         end
     end
 end

--- a/test/lexer_tests.jl
+++ b/test/lexer_tests.jl
@@ -2,123 +2,123 @@ using ChunkedJSONL: prepare_buffer!
 using Test
 
 @testset "initial buffer fill" begin
-    buf = fill(UInt8(' '), 10);
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer(""), buf, UInt32(0)) == 0
 
-    buf = fill(UInt8(' '), 10);
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer(" "), buf, UInt32(0)) == 0
 
-    buf = fill(UInt8(' '), 1);
+    buf = zeros(UInt8, 1);
     @test prepare_buffer!(IOBuffer(" "), buf, UInt32(0)) == 0
 
-    buf = fill(UInt8(' '), 1);
+    buf = zeros(UInt8, 1);
     @test prepare_buffer!(IOBuffer("  "), buf, UInt32(0)) == 0
 
-    buf = fill(UInt8(' '), 2);
+    buf = zeros(UInt8, 2);
     @test prepare_buffer!(IOBuffer("  "), buf, UInt32(0)) == 0
 
 
-    buf = fill(UInt8(' '), 10);
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer(" 1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = fill(UInt8(' '), 1);
+    buf = zeros(UInt8, 1);
     @test prepare_buffer!(IOBuffer(" 1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = fill(UInt8(' '), 1);
+    buf = zeros(UInt8, 1);
     @test prepare_buffer!(IOBuffer("  1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = fill(UInt8(' '), 2);
+    buf = zeros(UInt8, 2);
     @test prepare_buffer!(IOBuffer("  1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = fill(UInt8(' '), 10);
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer("1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = fill(UInt8(' '), 1);
+    buf = zeros(UInt8, 1);
     @test prepare_buffer!(IOBuffer("1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = fill(UInt8(' '), 2);
+    buf = zeros(UInt8, 2);
     @test prepare_buffer!(IOBuffer("1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
 
-    buf = fill(UInt8(' '), 10);
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer("12"), buf, UInt32(0)) == 2
     @test buf[1] == UInt8('1')
     @test buf[2] == UInt8('2')
 
-    buf = fill(UInt8(' '), 1);
+    buf = zeros(UInt8, 1);
     @test prepare_buffer!(IOBuffer("12"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = fill(UInt8(' '), 2);
+    buf = zeros(UInt8, 2);
     @test prepare_buffer!(IOBuffer("12"), buf, UInt32(0)) == 2
     @test buf[1] == UInt8('1')
     @test buf[2] == UInt8('2')
 end
 
 @testset "initial buffer fill with BOM" begin
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf"), buf, UInt32(0)) == 0
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf "), buf, UInt32(0)) == 0
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    buf = zeros(UInt8, 4);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf "), buf, UInt32(0)) == 0
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    buf = zeros(UInt8, 5);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf  "), buf, UInt32(0)) == 0
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    buf = zeros(UInt8, 5);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf  "), buf, UInt32(0)) == 0
 
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf 1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    buf = zeros(UInt8, 4);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf 1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    buf = zeros(UInt8, 4);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf  1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    buf = zeros(UInt8, 5);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf  1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    buf = zeros(UInt8, 4);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    buf = zeros(UInt8, 5);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf1"), buf, UInt32(0)) == 1
     @test buf[1] == UInt8('1')
 
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    buf = zeros(UInt8, 10);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf12"), buf, UInt32(0)) == 2
     @test buf[1] == UInt8('1')
     @test buf[2] == UInt8('2')
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    buf = zeros(UInt8, 4);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf12"), buf, UInt32(0)) == 2
     @test buf[1] == UInt8('1')
     @test buf[2] == UInt8('2')
 
-    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    buf = zeros(UInt8, 5);
     @test prepare_buffer!(IOBuffer("\xef\xbb\xbf12"), buf, UInt32(0)) == 2
     @test buf[1] == UInt8('1')
     @test buf[2] == UInt8('2')

--- a/test/lexer_tests.jl
+++ b/test/lexer_tests.jl
@@ -1,0 +1,145 @@
+using ChunkedJSONL: prepare_buffer!
+using Test
+
+@testset "initial buffer fill" begin
+    buf = fill(UInt8(' '), 10);
+    @test prepare_buffer!(IOBuffer(""), buf, UInt32(0)) == 0
+
+    buf = fill(UInt8(' '), 10);
+    @test prepare_buffer!(IOBuffer(" "), buf, UInt32(0)) == 0
+
+    buf = fill(UInt8(' '), 1);
+    @test prepare_buffer!(IOBuffer(" "), buf, UInt32(0)) == 0
+
+    buf = fill(UInt8(' '), 1);
+    @test prepare_buffer!(IOBuffer("  "), buf, UInt32(0)) == 0
+
+    buf = fill(UInt8(' '), 2);
+    @test prepare_buffer!(IOBuffer("  "), buf, UInt32(0)) == 0
+
+
+    buf = fill(UInt8(' '), 10);
+    @test prepare_buffer!(IOBuffer(" 1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = fill(UInt8(' '), 1);
+    @test prepare_buffer!(IOBuffer(" 1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = fill(UInt8(' '), 1);
+    @test prepare_buffer!(IOBuffer("  1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = fill(UInt8(' '), 2);
+    @test prepare_buffer!(IOBuffer("  1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = fill(UInt8(' '), 10);
+    @test prepare_buffer!(IOBuffer("1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = fill(UInt8(' '), 1);
+    @test prepare_buffer!(IOBuffer("1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = fill(UInt8(' '), 2);
+    @test prepare_buffer!(IOBuffer("1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+
+    buf = fill(UInt8(' '), 10);
+    @test prepare_buffer!(IOBuffer("12"), buf, UInt32(0)) == 2
+    @test buf[1] == UInt8('1')
+    @test buf[2] == UInt8('2')
+
+    buf = fill(UInt8(' '), 1);
+    @test prepare_buffer!(IOBuffer("12"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = fill(UInt8(' '), 2);
+    @test prepare_buffer!(IOBuffer("12"), buf, UInt32(0)) == 2
+    @test buf[1] == UInt8('1')
+    @test buf[2] == UInt8('2')
+end
+
+@testset "initial buffer fill with BOM" begin
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf"), buf, UInt32(0)) == 0
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf "), buf, UInt32(0)) == 0
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf "), buf, UInt32(0)) == 0
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf  "), buf, UInt32(0)) == 0
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf  "), buf, UInt32(0)) == 0
+
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf 1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf 1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf  1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf  1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf1"), buf, UInt32(0)) == 1
+    @test buf[1] == UInt8('1')
+
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 7));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf12"), buf, UInt32(0)) == 2
+    @test buf[1] == UInt8('1')
+    @test buf[2] == UInt8('2')
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 1));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf12"), buf, UInt32(0)) == 2
+    @test buf[1] == UInt8('1')
+    @test buf[2] == UInt8('2')
+
+    buf = vcat(b"\xef\xbb\xbf", fill(UInt8(' '), 2));
+    @test prepare_buffer!(IOBuffer("\xef\xbb\xbf12"), buf, UInt32(0)) == 2
+    @test buf[1] == UInt8('1')
+    @test buf[2] == UInt8('2')
+end
+
+@testset "buffer refill" begin
+    buf = zeros(UInt8, 10)
+    io = IOBuffer("xxx12")
+    skip(io, 3)
+    @test prepare_buffer!(io, buf, UInt32(10)) == 2
+    @test buf[1] == UInt8('1')
+    @test buf[2] == UInt8('2')
+
+    buf = zeros(UInt8, 10)
+    buf[9] = 0x09
+    buf[10] = 0x0a
+    io = IOBuffer("xxx12")
+    skip(io, 3)
+    @test prepare_buffer!(io, buf, UInt32(8)) == 2
+    @test buf[1] == 0x09
+    @test buf[2] == 0x0a
+    @test buf[3] == UInt8('1')
+    @test buf[4] == UInt8('2')
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,6 @@ using Test
 Threads.nthreads() == 1 && @warn "Running tests with a single thread -- won't be able to spot concurrency issues"
 
 @testset "ChunkedJSONL.jl" begin
+    include("lexer_tests.jl")
     include("basic_tests.jl")
 end


### PR DESCRIPTION
Before, we didn't properly check that the input was empty, and if the `undef` allocation of the byte buffer started with a byte corresponding to an ascii space, we would just go ahead and try to skip it (this would get us into an infinite recursion where we would pass the zero `bytes_read_in` over and over again to the `prepare_buffer!` function)

We now also handle leading whitespace spanning multiple chunks of input.