### PR TITLE
Use `@warn` instead of `@error` to log task errors

### DIFF
--- a/src/ChunkedJSONL.jl
+++ b/src/ChunkedJSONL.jl
@@ -35,6 +35,7 @@ function estimate_task_size(parsing_ctx::ParsingContext)
     min_rows = max(2, cld(MIN_TASK_SIZE_IN_BYTES, ceil(Int, last(parsing_ctx.eols)  / length(parsing_ctx.eols))))
     return max(min_rows, cld(ceil(Int, length(parsing_ctx.eols) * ((1 + length(parsing_ctx.bytes)) / (1 + last(parsing_ctx.eols)))), parsing_ctx.maxtasks))
 end
+_nonspace(b::UInt8) = !isspace(Char(b))
 
 include("read_and_lex.jl")
 # include("init_parsing.jl")

--- a/src/parser_doublebuffer.jl
+++ b/src/parser_doublebuffer.jl
@@ -47,7 +47,7 @@ function process_and_consume_task(parsing_queue::Channel{T}, result_buffers::Vec
             task_done!(consume_ctx, ctx, result_buf)
         end
     catch e
-        @warn "Task failed" exception=(e, catch_backtrace())
+        @warn "JSONLines parsing task failed" exception=(e, catch_backtrace())
         # If there was an exception, immediately stop processing the queue
         isopen(parsing_queue) && close(parsing_queue, e)
         # if the io_task was waiting for work to finish, we'll interrupt it here

--- a/src/parser_doublebuffer.jl
+++ b/src/parser_doublebuffer.jl
@@ -47,7 +47,7 @@ function process_and_consume_task(parsing_queue::Channel{T}, result_buffers::Vec
             task_done!(consume_ctx, ctx, result_buf)
         end
     catch e
-        @error "Task failed" exception=(e, catch_backtrace())
+        @warn "Task failed" exception=(e, catch_backtrace())
         # If there was an exception, immediately stop processing the queue
         isopen(parsing_queue) && close(parsing_queue, e)
         # if the io_task was waiting for work to finish, we'll interrupt it here

--- a/src/parser_singlebuffer.jl
+++ b/src/parser_singlebuffer.jl
@@ -34,7 +34,7 @@ function process_and_consume_task(parsing_queue::Channel{T}, result_buffers::Vec
             task_done!(consume_ctx, parsing_ctx, result_buf)
         end
     catch e
-        @warn "Task failed" exception=(e, catch_backtrace())
+        @warn "JSONLines parsing task failed" exception=(e, catch_backtrace())
         # If there was an exception, immediately stop processing the queue
         isopen(parsing_queue) && close(parsing_queue, e)
         # if the io/lexing was waiting for work to finish, we'll interrupt it here

--- a/src/parser_singlebuffer.jl
+++ b/src/parser_singlebuffer.jl
@@ -34,7 +34,7 @@ function process_and_consume_task(parsing_queue::Channel{T}, result_buffers::Vec
             task_done!(consume_ctx, parsing_ctx, result_buf)
         end
     catch e
-        @error "Task failed" exception=(e, catch_backtrace())
+        @warn "Task failed" exception=(e, catch_backtrace())
         # If there was an exception, immediately stop processing the queue
         isopen(parsing_queue) && close(parsing_queue, e)
         # if the io/lexing was waiting for work to finish, we'll interrupt it here

--- a/src/read_and_lex.jl
+++ b/src/read_and_lex.jl
@@ -17,7 +17,6 @@ end_of_stream(io::GzipDecompressorStream) = eof(io)
 readbytesall!(io::IOStream, buf, n) = UInt32(Base.readbytes!(io, buf, n; all = true))
 readbytesall!(io::IO, buf, n) = UInt32(Base.readbytes!(io, buf, n))
 
-_nonspace(b::UInt8) = !isspace(Char(b))
 function _skip_over_initial_whitespace_and_bom!(io, buf, bytes_read_in)
     bytes_read_in == 0 && return bytes_read_in # empty input -- nothing to skip
     buffersize = UInt32(length(buf))

--- a/src/row_parsing.jl
+++ b/src/row_parsing.jl
@@ -1,5 +1,3 @@
-_nonspace(b::UInt8) = !isspace(Char(b))
-
 function _parse_rows_forloop!(result_buf::TaskResultBuffer, task::AbstractVector{UInt32}, buf)
     tape = result_buf.tape
     empty!(result_buf)


### PR DESCRIPTION
The other changes get rid of this message:
```
┌ ChunkedJSONL [f218240f-9760-4928-9282-fb77ffd82776]
│  WARNING: Method definition _nonspace(UInt8) in module ChunkedJSONL at /Users/tdrvostep/_proj/ChunkedJSONL.jl/src/read_and_lex.jl:20 overwritten at /Users/tdrvostep/_proj/ChunkedJSONL.jl/src/row_parsing.jl:1.
│    ** incremental compilation may be fatally broken for this module **
└  
```